### PR TITLE
Суём неправильную ссылку на пайплайн

### DIFF
--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -62,7 +62,7 @@ func classifyPipelineStatus(status models.PipelineStatus) taskStatus {
 
 func pipelineLess(left *models.Pipeline, right *models.Pipeline) bool {
 	if classifyPipelineStatus(left.Status) == classifyPipelineStatus(right.Status) {
-		return left.StartedAt.Before(right.StartedAt)
+		return left.StartedAt.After(right.StartedAt)
 	}
 
 	return classifyPipelineStatus(left.Status) > classifyPipelineStatus(right.Status)


### PR DESCRIPTION
При выборе какой пайплайн отобразить на фронте, почему-то выбирался первый по времени. Хотя очевидно что хочется показывать тот, что был последним.