### PR TITLE
Improved groups scoring display

### DIFF
--- a/internal/scorer/results.go
+++ b/internal/scorer/results.go
@@ -58,6 +58,15 @@ type ScoredTaskGroup struct {
 	MaxScore int
 }
 
+type ScoredScoringGroup struct {
+	Name          string
+	Score         int
+	MaxScore      int
+	Weight        float64
+	WeightedScore float64
+	TenScaleScore float64
+}
+
 type User struct {
 	FirstName     string
 	LastName      string
@@ -70,10 +79,12 @@ func (u User) FullName() string {
 }
 
 type UserScores struct {
-	Groups    []ScoredTaskGroup
-	Score     int
-	MaxScore  int
-	FinalMark float64
+	Groups        []ScoredTaskGroup
+	ScoringGroups []ScoredScoringGroup
+	Score         int
+	MaxScore      int
+	FinalMark     float64
+	MaxFinalMark  float64
 
 	User User
 }

--- a/internal/scorer/scorer.go
+++ b/internal/scorer/scorer.go
@@ -266,16 +266,26 @@ func (s Scorer) calcUserScoresImpl(currentDeadlines *deadlines.Deadlines, user *
 	overrides := parseOverrides(rawOverrides)
 
 	scores := &UserScores{
-		Groups:    make([]ScoredTaskGroup, 0),
-		Score:     0,
-		MaxScore:  0,
-		FinalMark: 0.0,
+		Groups:        make([]ScoredTaskGroup, 0),
+		ScoringGroups: make([]ScoredScoringGroup, 0),
+		Score:         0,
+		MaxScore:      0,
+		FinalMark:     0.0,
 		User: User{
 			FirstName:     user.FirstName,
 			LastName:      user.LastName,
 			GitlabLogin:   *user.GitlabLogin,
 			GitlabProject: s.projects.MakeProjectName(user),
 		},
+	}
+
+	groupStats := make(map[string]*ScoredScoringGroup)
+	for _, g := range currentDeadlines.Scoring.Groups {
+		groupStats[g.Name] = &ScoredScoringGroup{
+			Name:     g.Name,
+			Weight:   g.Weight,
+			MaxScore: g.MaxScore,
+		}
 	}
 
 	for _, group := range currentDeadlines.Assignments {
@@ -337,9 +347,41 @@ func (s Scorer) calcUserScoresImpl(currentDeadlines *deadlines.Deadlines, user *
 		})
 		scores.Score += totalScore
 		scores.MaxScore += maxTotalScore
-		if scoringGroup != nil && scoringGroup.MaxScore > 0 {
-			scores.FinalMark += scoringGroup.Weight * float64(totalScore) / float64(scoringGroup.MaxScore)
+
+		if scoringGroup != nil {
+			stats, ok := groupStats[scoringGroup.Name]
+			if !ok {
+				stats = &ScoredScoringGroup{
+					Name:     scoringGroup.Name,
+					Weight:   scoringGroup.Weight,
+					MaxScore: scoringGroup.MaxScore,
+				}
+				groupStats[scoringGroup.Name] = stats
+			}
+			stats.Score += totalScore
+			if scoringGroup.MaxScore == 0 {
+				stats.MaxScore += maxTotalScore
+			}
 		}
+	}
+
+	for _, g := range currentDeadlines.Scoring.Groups {
+		stats, ok := groupStats[g.Name]
+		if !ok {
+			continue
+		}
+
+		if stats.MaxScore > 0 {
+			stats.WeightedScore = stats.Weight * float64(stats.Score) / float64(stats.MaxScore)
+			stats.TenScaleScore = 10.0 * float64(stats.Score) / float64(stats.MaxScore)
+		} else {
+			stats.WeightedScore = 0
+			stats.TenScaleScore = 0
+		}
+
+		scores.MaxFinalMark += stats.Weight
+		scores.FinalMark += stats.WeightedScore
+		scores.ScoringGroups = append(scores.ScoringGroups, *stats)
 	}
 
 	return scores, nil

--- a/web/home.tmpl
+++ b/web/home.tmpl
@@ -81,16 +81,41 @@
         </nav>
 
         {{ if .Scores }}
+            <div class="container p-2 my-4">
+                <div class="bg-light rounded p-4 shadow-sm d-flex flex-wrap align-items-center justify-content-between">
+                    <div class="d-flex align-items-center me-4 mb-2 mb-md-0">
+                        <div class="me-4 pe-4 border-end">
+                            <div class="text-uppercase text-muted small fw-bold" style="font-size: 0.7rem; letter-spacing: 1px;">Final Mark</div>
+                            <div class="display-5 fw-bold text-dark lh-1">{{printf "%.2f" .Scores.FinalMark}}</div>
+                        </div>
+                        <div class="d-flex gap-4">
+                            {{ range .Scores.ScoringGroups }}
+                            <div>
+                                <div class="text-muted small" style="font-size: 0.75rem;">{{ .Name }}</div>
+                                <div class="fw-bold h5 mb-0">{{printf "%.1f" .TenScaleScore}}<span class="text-muted fw-normal small">/10</span></div>
+                                <div class="text-muted small" style="font-size: 0.7rem;">{{ .Score }} / {{ .MaxScore }}</div>
+                            </div>
+                            {{ end }}
+                        </div>
+                    </div>
+                    <div class="text-muted small">
+                        Max: {{printf "%.2f" .Scores.MaxFinalMark}}
+                    </div>
+                </div>
+            </div>
+
             {{ range .Scores.Groups }}
                 <div class="container p-2 my-5">
-                    <div class="p-2">
+                    <div class="p-2 mb-3">
                         <a name="{{ .PrettyTitle }}" href="#{{ .PrettyTitle }}" class="text-decoration-none text-dark">
-                            <h1 class="row">
-                                <div class="col-8">
+                            <h1 class="row align-items-baseline">
+                                <div class="col-auto">
                                     {{ .PrettyTitle }}
-                                    <span class="text-muted">{{ .Deadline.String }}</span>
                                 </div>
-                                <span class="col text-end">Total score: {{ .Score }} / {{ .MaxScore }}</span>
+                                <div class="col-auto">
+                                    <span class="h4 text-muted fw-light">{{ .Deadline.String }}</span>
+                                </div>
+                                <span class="col text-end h3 fw-light text-muted">Total score: {{ .Score }} / {{ .MaxScore }}</span>
                             </h1>
                         </a>
                     </div>

--- a/web/standings.tmpl
+++ b/web/standings.tmpl
@@ -134,8 +134,11 @@
                         <tr>
                             <th scope="col" class="num sticky-header sticky-col first-col corner">#</th>
                             <th scope="col" class="name sticky-header sticky-col second-col corner">Student</th>
-                            {{ if $.GroupConfig.ShowMarks }}<th scope="col" class="sticky-header">Mark</th>{{ end }}
-                            <th scope="col" class="sticky-header">Score</th>
+                            <th scope="col" class="sticky-header">Final Mark</th>
+                            {{ range .Standings.Deadlines.Scoring.Groups }}
+                                <th scope="col" class="sticky-header">{{ .Name }} ({{ .Weight }})</th>
+                            {{ end }}
+                            <th scope="col" class="sticky-header">Total Score</th>
                             {{ range .Standings.Deadlines.Assignments }}
                                 {{ range .Tasks }}
                                     <th scope="col" class="task sticky-header"><span class="task-name">{{ .Task | prettifyTaskName }}</span></th>
@@ -148,7 +151,12 @@
                             <tr>
                                 <th scope="row" class="num sticky-col first-col">0</th>
                                 <th scope="row" class="name sticky-col second-col">Chuck Norris</th>
-                                {{ if $.GroupConfig.ShowMarks }}<td>13.37</td>{{ end }}
+                                <td>{{printf "%.2f" .MaxFinalMark}}</td>
+                                {{ range .ScoringGroups }}
+                                    <td class="text-center" title="{{ .MaxScore }}/{{ .MaxScore }}">
+                                        10.0
+                                    </td>
+                                {{ end }}
                                 <td>{{ .MaxScore }}</td>
                                 {{ range .Groups }}
                                     {{ range .Tasks }}
@@ -161,7 +169,12 @@
                             <tr>
                                 <th scope="row" class="num sticky-col first-col">{{ inc $index }}</th>
                                 <th scope="row" class="name sticky-col second-col">{{ $user.User.FirstName }} {{ $user.User.LastName }}</th>
-                                {{ if $.GroupConfig.ShowMarks }}<td>{{printf "%.3f" $user.FinalMark}}</td>{{ end }}
+                                <td>{{printf "%.2f" $user.FinalMark}}</td>
+                                {{ range $user.ScoringGroups }}
+                                    <td class="text-center" title="{{ .Score }}/{{ .MaxScore }}">
+                                        {{printf "%.1f" .TenScaleScore}}
+                                    </td>
+                                {{ end }}
                                 <td>{{ $user.Score }}</td>
                                 {{ range $user.Groups }}
                                     {{ range .Tasks }}


### PR DESCRIPTION
Теперь на главной странице отображается небольшая панель с информацией о текущей накопленной оценке по каждому элементу домашних заданий. Веса берутся из поля `weight` у `ScoringGroup`.  Также эти промежуточные оценки выводятся в Standings.
Немного уменьшил шрифты на дедлайнах и total score.

<img width="1367" height="435" alt="image" src="https://github.com/user-attachments/assets/8387fbc4-f0a7-4297-83ba-47b62cfc46f8" />
<img width="901" height="219" alt="image" src="https://github.com/user-attachments/assets/f7060c02-0e94-4348-b85b-597bd8bb11f1" />
